### PR TITLE
Prevent reload page, with message if device is connected

### DIFF
--- a/js/spjs.js
+++ b/js/spjs.js
@@ -14,6 +14,11 @@ function spjsInit() {
         $('#command').val('');
     }
   });
+  window.onbeforeunload = function() {
+      if (isConnected) {
+        return "Whow, you still have a connected device. First disconnect, before you leave or refresh your page.";
+      }
+    }
 };
 
 function sendGcode(gcode) {


### PR DESCRIPTION
#19 Temporary fix that pops up a notification if isConnected returns true
